### PR TITLE
Use concurrency feature to cancal running jobs and run the new ones.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
 


### PR DESCRIPTION
[skip ci] Use concurrency feature to cancal running jobs and run the new ones.