### PR TITLE
Update from python3.10 to 3.11

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine as base
+FROM python:3.11-alpine as base
 FROM base as builder
 RUN apk add build-base
 RUN mkdir /install
@@ -12,4 +12,4 @@ ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app
-CMD ["python3", "/app/agent/all_tlds_agent.py"]
+CMD ["python3.11", "/app/agent/all_tlds_agent.py"]

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: all_tlds
-version: 0.3.4
+version: 0.3.5
 image: images/logo.png
 description: |
   ## Getting Started


### PR DESCRIPTION
**Update from python3.10 to 3.11:**

Steps:
- update python-version in .github/workflows/pylint.yml
- update python-version in .github/workflows/pytest.yml
- update python-version in docker file

Steps to test the new version:

- run unit tests using python 3.11 in virtual env

```bash
virtualenv -p python3.11 venv
source venv/bin/activate
pip install -r requirement.txt
pip install -r tests/test-requirement.txt

mypy agent/ tests/
black .
pylint --rcfile=.pylintrc --ignore=tests/ agent/
pylint --rcfile=.pylintrc -d C0103,W0613 tests/
pytest
```

- run test after building the docker image

```bash
ostorlab agent build -f ostorlab.yaml -o dev --no-cache
ostorlab scan run --install --follow=agent/dev/all_tlds --agent agent/dev/all_tlds --agent agent/ostorlab/nuclei domain-name ostorlab.co
```